### PR TITLE
feat: add inline screenshot command @botname screenshot

### DIFF
--- a/handlers/camera.py
+++ b/handlers/camera.py
@@ -232,6 +232,67 @@ async def overlay_weather_on_image(image_bytes: bytes, city_name: str = "Izhevsk
         logger.error(f"Error overlaying weather on image: {e}")
         return image_bytes
 
+async def perform_screenshot_capture(city_name: str = "Izhevsk") -> tuple[bytes | None, str | None, str | None]:
+    """
+    Handles the full capture flow: ONVIF/RTSP -> Weather Overlay -> Disk Save.
+    Returns: (image_content, filename, error_msg)
+    """
+    try:
+        snapshot_uri, rtsp_uri = await get_camera_snapshot()
+        image_content = None
+        
+        # 1. Try Snapshot URI
+        if snapshot_uri:
+            def download_image():
+                try:
+                    response = requests.get(
+                        snapshot_uri, 
+                        auth=HTTPDigestAuth(CAMERA_USER, CAMERA_PASSWORD), 
+                        timeout=10.0,
+                        verify=False
+                    )
+                    if response.status_code == 401:
+                        response = requests.get(
+                            snapshot_uri, 
+                            auth=HTTPBasicAuth(CAMERA_USER, CAMERA_PASSWORD), 
+                            timeout=10.0,
+                            verify=False
+                        )
+                    return response if response.status_code == 200 and response.content else None
+                except Exception:
+                    return None
+
+            response = await asyncio.to_thread(download_image)
+            if response:
+                image_content = response.content
+
+        # 2. Fallback to RTSP
+        if not image_content and rtsp_uri:
+            logger.info("Falling back to RTSP capture...")
+            image_content = await capture_rtsp_frame(rtsp_uri)
+
+        if not image_content:
+            return None, None, "Failed to capture image from both Snapshot URI and RTSP stream."
+
+        # 3. Add Weather Overlay
+        image_content = await overlay_weather_on_image(image_content, city_name=city_name)
+
+        # 4. Save to Disk
+        SCREENSHOTS_DIR.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+        filename = f"snapshot_{timestamp}.jpg"
+        filepath = SCREENSHOTS_DIR / filename
+        
+        with open(filepath, "wb") as f:
+            f.write(image_content)
+        logger.info(f"Saved snapshot to {filepath}")
+        
+        return image_content, filename, None
+
+    except Exception as e:
+        logger.error(f"Error in perform_screenshot_capture: {e}")
+        return None, None, str(e)
+
 @router.message(Command("camera"))
 async def cmd_camera(message: types.Message, command: CommandObject):
     """Handles the /camera screenshot and /camera video [sec] commands."""
@@ -241,69 +302,15 @@ async def cmd_camera(message: types.Message, command: CommandObject):
     if subcommand == "screenshot":
         processing_msg = await message.answer("📸 Connecting to camera and capturing screenshot...")
         
-        try:
-            snapshot_uri, rtsp_uri = await get_camera_snapshot()
-            image_content = None
-            
-            # 1. Try Snapshot URI
-            if snapshot_uri:
-                def download_image():
-                    try:
-                        response = requests.get(
-                            snapshot_uri, 
-                            auth=HTTPDigestAuth(CAMERA_USER, CAMERA_PASSWORD), 
-                            timeout=10.0,
-                            verify=False
-                        )
-                        if response.status_code == 401:
-                            response = requests.get(
-                                snapshot_uri, 
-                                auth=HTTPBasicAuth(CAMERA_USER, CAMERA_PASSWORD), 
-                                timeout=10.0,
-                                verify=False
-                            )
-                        return response if response.status_code == 200 and response.content else None
-                    except Exception:
-                        return None
-
-                response = await asyncio.to_thread(download_image)
-                if response:
-                    image_content = response.content
-
-            # 2. Fallback to RTSP
-            if not image_content and rtsp_uri:
-                logger.info("Falling back to RTSP capture...")
-                image_content = await capture_rtsp_frame(rtsp_uri)
-
-            # 3. Add Weather Overlay (NEW)
-            if image_content:
-                image_content = await overlay_weather_on_image(image_content, city_name="Izhevsk")
-
-            # 4. Save and Send
-            if image_content:
-                # Ensure directory exists
-                SCREENSHOTS_DIR.mkdir(parents=True, exist_ok=True)
-                
-                # Create timestamped filename
-                timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
-                filename = f"snapshot_{timestamp}.jpg"
-                filepath = SCREENSHOTS_DIR / filename
-                
-                # Save to disk
-                with open(filepath, "wb") as f:
-                    f.write(image_content)
-                logger.info(f"Saved snapshot to {filepath}")
-
-                # Send to Telegram
-                photo = BufferedInputFile(image_content, filename=filename)
-                await message.answer_photo(photo, caption=f"🖼️ Camera Snapshot from {CAMERA_IP}\nSaved as: <code>{filename}</code>")
-                await processing_msg.delete()
-            else:
-                await message.answer("❌ Failed to capture image from both Snapshot URI and RTSP stream.")
-                    
-        except Exception as e:
-            logger.error(f"Error in cmd_camera screenshot: {e}")
-            await message.answer(f"❌ Error capturing screenshot: {str(e)}")
+        image_content, filename, error_msg = await perform_screenshot_capture()
+        
+        if image_content:
+            # Send to Telegram
+            photo = BufferedInputFile(image_content, filename=filename)
+            await message.answer_photo(photo, caption=f"🖼️ Camera Snapshot from {CAMERA_IP}\nSaved as: <code>{filename}</code>")
+            await processing_msg.delete()
+        else:
+            await message.answer(f"❌ {error_msg}")
             
     elif subcommand == "video":
         duration = 5

--- a/handlers/help.py
+++ b/handlers/help.py
@@ -9,8 +9,8 @@ async def cmd_help(message: types.Message):
     help_text = (
         f"<b>🤖 Bot Version:</b> <code>{BOT_VERSION}</code>\n\n"
         "<b>✨ Inline Mode</b>\n"
-        "Type <code>@groldtestbot [city]</code> in any chat for quick weather. "
-        "Try <code>@groldtestbot</code> without text to use your current location!\n\n"
+        "Type <code>@groldtestbot [city]</code> for quick weather. "
+        "Try <code>@groldtestbot screenshot</code> to capture a live frame!\n\n"
         "<b>🛠️ Available Commands:</b>\n"
         "/start - Welcome message\n"
         "/help - Show this guide\n"

--- a/handlers/inline.py
+++ b/handlers/inline.py
@@ -19,8 +19,32 @@ except FileNotFoundError:
 @router.inline_query()
 async def inline_weather_handler(inline_query: types.InlineQuery):
     """Handles inline queries for weather with autocompletion."""
-    query = inline_query.query.strip()
+    query = inline_query.query.strip().lower()
     results = []
+
+    # --- Screenshot Handling ---
+    if query == "screenshot":
+        # Check permissions (manual check since middleware doesn't apply to inline_query results in the same way)
+        from database import get_user, get_command_min_role
+        from middlewares.auth import ROLES_ORDER
+        
+        user = get_user(inline_query.from_user.id)
+        user_role = user["role"] if user and user["is_authorized"] else "PUBLIC"
+        min_role = get_command_min_role("camera") or "PUBLIC"
+        
+        if ROLES_ORDER.get(user_role, 0) >= ROLES_ORDER.get(min_role, 0):
+            results.append(
+                types.InlineQueryResultArticle(
+                    id="camera_screenshot",
+                    title="📸 Capture Camera Screenshot",
+                    description="Captures a live frame from the camera with weather overlay.",
+                    input_message_content=types.InputTextMessageContent(
+                        message_text="📸 Connecting to camera and capturing screenshot..."
+                    )
+                )
+            )
+            await inline_query.answer(results, cache_time=0) # No cache for live screenshots
+            return
 
     if not query and not inline_query.location:
         # If query is empty and no location provided, show an instructional message

--- a/handlers/inline.py
+++ b/handlers/inline.py
@@ -1,9 +1,10 @@
 import logging
 import asyncio
 from uuid import uuid4
-from aiogram import Router, types
-from aiogram.types import InlineQueryResultArticle, InputTextMessageContent
+from aiogram import Router, types, F
+from aiogram.types import InlineQueryResultArticle, InputTextMessageContent, InputMediaPhoto, BufferedInputFile
 from handlers.weather import get_weather, format_weather_message
+from handlers.camera import perform_screenshot_capture
 
 router = Router()
 logger = logging.getLogger(__name__)
@@ -148,3 +149,24 @@ async def inline_weather_handler(inline_query: types.InlineQuery):
         )
 
     await inline_query.answer(results, cache_time=60)
+
+@router.chosen_inline_result(F.result_id == "camera_screenshot")
+async def on_chosen_screenshot_result(chosen_result: types.ChosenInlineResult):
+    """Executes the screenshot capture when the inline result is selected."""
+    logger.info(f"Inline screenshot requested by {chosen_result.from_user.id}")
+    
+    image_content, filename, error_msg = await perform_screenshot_capture()
+    
+    if image_content:
+        photo = BufferedInputFile(image_content, filename=filename)
+        media = InputMediaPhoto(media=photo, caption=f"🖼️ Camera Snapshot\nSaved as: <code>{filename}</code>")
+        
+        await chosen_result.bot.edit_message_media(
+            media=media,
+            inline_message_id=chosen_result.inline_message_id
+        )
+    else:
+        await chosen_result.bot.edit_message_text(
+            text=f"❌ Failed to capture screenshot: {error_msg}",
+            inline_message_id=chosen_result.inline_message_id
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "telegram-bot"
-version = "0.6.3"
+version = "0.6.4"
 description = "telegram bot experiments"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/test_inline_screenshot.py
+++ b/tests/test_inline_screenshot.py
@@ -1,0 +1,26 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from handlers.inline import inline_weather_handler
+from aiogram.types import InlineQuery, User
+
+@pytest.mark.asyncio
+async def test_inline_screenshot_query_authorized():
+    inline_query = MagicMock(spec=InlineQuery)
+    inline_query.query = "screenshot"
+    inline_query.from_user = MagicMock(spec=User)
+    inline_query.from_user.id = 123
+    inline_query.location = None
+    inline_query.answer = AsyncMock()
+
+    # Mock database and auth
+    with patch("database.get_user") as mock_get_user, \
+         patch("database.get_command_min_role") as mock_get_role:
+        
+        mock_get_role.return_value = "PUBLIC"
+        mock_get_user.return_value = {"role": "USER", "is_authorized": 1}
+        
+        await inline_weather_handler(inline_query)
+        
+    inline_query.answer.assert_called_once()
+    results = inline_query.answer.call_args[0][0]
+    assert any(r.id == "camera_screenshot" for r in results)

--- a/tests/test_inline_screenshot.py
+++ b/tests/test_inline_screenshot.py
@@ -24,3 +24,23 @@ async def test_inline_screenshot_query_authorized():
     inline_query.answer.assert_called_once()
     results = inline_query.answer.call_args[0][0]
     assert any(r.id == "camera_screenshot" for r in results)
+
+from aiogram.types import ChosenInlineResult
+
+@pytest.mark.asyncio
+async def test_chosen_screenshot_result_success():
+    chosen_result = MagicMock(spec=ChosenInlineResult)
+    chosen_result.result_id = "camera_screenshot"
+    chosen_result.inline_message_id = "test_inline_id"
+    chosen_result.from_user = MagicMock(spec=User)
+    chosen_result.from_user.id = 123
+    chosen_result.bot = AsyncMock()
+
+    from handlers.inline import on_chosen_screenshot_result
+    
+    with patch("handlers.inline.perform_screenshot_capture") as mock_capture:
+        mock_capture.return_value = (b"fake_data", "test.jpg", None)
+        
+        await on_chosen_screenshot_result(chosen_result)
+        
+    chosen_result.bot.edit_message_media.assert_called_once()


### PR DESCRIPTION
## Summary
- Refactored `handlers/camera.py` to extract core capture logic into `perform_screenshot_capture`.
- Implemented an inline query result in `handlers/inline.py` for the "screenshot" keyword.
- Added a `ChosenInlineResult` handler in `handlers/inline.py` to capture and send a photo with a weather overlay when the result is selected.
- Updated `handlers/help.py` and bumped version to `0.6.4`.

## Test Plan
- [x] Run `uv run pytest tests/test_camera.py tests/test_inline_screenshot.py` - all 12 tests pass.
- [ ] Manual verification in Telegram: type `@botname screenshot` and verify that the photo is sent after the selection.