### PR TITLE
feat: EXIF-based historical weather for photos

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,7 +3,7 @@ import logging
 from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
 from config import BOT_TOKEN, AUDIO_CLEANUP_DAYS
-from handlers import start, help, time, top, photo, group, auto_reply, weather, forecast, inline, log, audio, circle, camera, rate, mygroups, webcams, admin_mgmt
+from handlers import start, help, time, top, photo, group, auto_reply, weather, forecast, inline, log, audio, circle, camera, rate, mygroups, webcams, admin_mgmt, exif_weather
 from tools.cleanup_audio import cleanup_old_audio
 from tools.migrate_auth import migrate_auth_file
 from database import init_db
@@ -61,6 +61,7 @@ async def main():
     dp.include_router(camera.router)
     dp.include_router(rate.router)
     dp.include_router(mygroups.router)
+    dp.include_router(exif_weather.router)
     dp.include_router(auto_reply.router)
 
     # Start polling

--- a/bot.py
+++ b/bot.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import sys
 from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
 from config import BOT_TOKEN, AUDIO_CLEANUP_DAYS
@@ -44,6 +45,7 @@ async def main():
     dp.message.middleware(AuthMiddleware())
 
     # Register routers
+    dp.include_router(exif_weather.router)
     dp.include_router(inline.router) # Inline queries
     dp.include_router(start.router)
     dp.include_router(help.router)
@@ -61,7 +63,6 @@ async def main():
     dp.include_router(camera.router)
     dp.include_router(rate.router)
     dp.include_router(mygroups.router)
-    dp.include_router(exif_weather.router)
     dp.include_router(auto_reply.router)
 
     # Start polling

--- a/handlers/exif_weather.py
+++ b/handlers/exif_weather.py
@@ -11,6 +11,9 @@ logger = logging.getLogger(__name__)
 
 def get_decimal_from_dms(dms, ref):
     """Converts Degrees, Minutes, Seconds to decimal coordinates."""
+    if not isinstance(dms, (list, tuple)) or len(dms) < 3:
+        logger.warning(f"Invalid DMS format provided: {dms}")
+        return None
     try:
         degrees = dms[0]
         minutes = dms[1]
@@ -26,8 +29,8 @@ def get_decimal_from_dms(dms, ref):
         if ref in ['S', 'W']:
             decimal = -decimal
         return decimal
-    except Exception:
-        logger.exception("Error converting DMS to decimal")
+    except (TypeError, ValueError) as e:
+        logger.exception(f"Error converting DMS to decimal: {e}")
         return None
 
 def extract_exif_data(image_bytes):
@@ -56,8 +59,8 @@ def extract_exif_data(image_bytes):
             return (lat, lon), dt_str
         
         return None, None
-    except Exception:
-        logger.exception("Error extracting EXIF data")
+    except (IOError, AttributeError, KeyError) as e:
+        logger.exception(f"Error extracting EXIF data: {e}")
         return None, None
 
 async def fetch_historical_weather(lat, lon, dt_str):
@@ -92,27 +95,29 @@ async def fetch_historical_weather(lat, lon, dt_str):
                     data = await response.json()
                     hourly = data.get("hourly", {})
                     
-                    # Safety check for hour index
-                    temps = hourly.get("temperature_2m", [])
-                    if not temps or hour >= len(temps):
-                        logger.error(f"Hour {hour} not found in hourly data (length {len(temps)})")
-                        return None
+                    # Safer data access
+                    hourly_data_keys = ["temperature_2m", "relative_humidity_2m", "wind_speed_10m", "cloud_cover", "weather_code"]
+                    hourly_values = {key: hourly.get(key, []) for key in hourly_data_keys}
 
-                    return {
-                        "temp": temps[hour],
-                        "humidity": hourly.get("relative_humidity_2m", [])[hour],
-                        "wind": hourly.get("wind_speed_10m", [])[hour],
-                        "clouds": hourly.get("cloud_cover", [])[hour],
-                        "code": hourly.get("weather_code", [])[hour],
-                        "date": date_str,
-                        "time": dt.strftime("%H:%M:%S")
-                    }
+                    if all(len(hourly_values[key]) > hour for key in hourly_data_keys):
+                        return {
+                            "temp": hourly_values["temperature_2m"][hour],
+                            "humidity": hourly_values["relative_humidity_2m"][hour],
+                            "wind": hourly_values["wind_speed_10m"][hour],
+                            "clouds": hourly_values["cloud_cover"][hour],
+                            "code": hourly_values["weather_code"][hour],
+                            "date": date_str,
+                            "time": dt.strftime("%H:%M:%S")
+                        }
+                    else:
+                        logger.error(f"Incomplete hourly data for hour {hour} in response.")
+                        return None
                 else:
                     error_text = await response.text()
                     logger.error(f"Open-Meteo returned status {response.status}: {error_text}")
                     return None
-    except Exception:
-        logger.exception("Error fetching historical weather")
+    except (aiohttp.ClientError, KeyError, IndexError, ValueError) as e:
+        logger.exception(f"Error fetching historical weather: {e}")
         return None
 
 def get_weather_condition(code):
@@ -159,7 +164,7 @@ async def process_photo_for_exif(message: types.Message, bot: Bot, file_id: str)
                 f"💨 <b>Wind Speed:</b> <code>{weather['wind']} km/h</code>\n"
                 f"🌥️ <b>Cloud Cover:</b> <code>{weather['clouds']}%</code>"
             )
-            await message.answer(report, parse_mode="HTML")
+            await message.answer(report)
         else:
             logger.info(f"Could not fetch weather for coordinates {coords} and date {dt_str}")
     else:

--- a/handlers/exif_weather.py
+++ b/handlers/exif_weather.py
@@ -38,31 +38,21 @@ def extract_exif_data(image_bytes):
         if not exif:
             return None, None
 
-        # GPSInfo is a separate dictionary often indexed by 34853 (0x8825)
-        gps_info = {}
-        for tag, value in exif.items():
-            decoded = ExifTags.TAGS.get(tag, tag)
-            if decoded == "GPSInfo":
-                # For Pillow 10+, getexif() might return GPSInfo in different ways
-                # but standard practice is to use get_ifd(0x8825)
-                pass
-
         # Try to get GPS IFD specifically
         gps_ifd = exif.get_ifd(0x8825)
         if gps_ifd:
+            # GPSLatitude is 2, GPSLatitudeRef is 1
             lat = get_decimal_from_dms(gps_ifd.get(2), gps_ifd.get(1))
+            # GPSLongitude is 4, GPSLongitudeRef is 3
             lon = get_decimal_from_dms(gps_ifd.get(4), gps_ifd.get(3))
             
-            # Timestamp (DateTimeOriginal is often in the main EXIF or 0x9003)
-            # Try main EXIF first (0x0132 is DateTime, 0x9003 is DateTimeOriginal)
+            # Timestamp
             dt_str = exif.get(0x9003) or exif.get(0x0132)
-            
-            # If not found in main, try get_ifd(0x8769) for Exif IFD
             if not dt_str:
                 exif_ifd = exif.get_ifd(0x8769)
                 if exif_ifd:
                     dt_str = exif_ifd.get(0x9003) or exif_ifd.get(0x9004)
-
+            
             return (lat, lon), dt_str
         
         return None, None
@@ -78,7 +68,15 @@ async def fetch_historical_weather(lat, lon, dt_str):
         date_str = dt.strftime("%Y-%m-%d")
         hour = dt.hour
 
-        url = "https://archive-api.open-meteo.com/v1/archive"
+        # Open-Meteo Archive API takes up to 2 days to update.
+        # If the date is very recent, use the forecast API.
+        days_diff = (datetime.now() - dt).days
+        
+        if days_diff <= 7:
+            url = "https://api.open-meteo.com/v1/forecast"
+        else:
+            url = "https://archive-api.open-meteo.com/v1/archive"
+
         params = {
             "latitude": lat,
             "longitude": lon,
@@ -93,24 +91,25 @@ async def fetch_historical_weather(lat, lon, dt_str):
                 if response.status == 200:
                     data = await response.json()
                     hourly = data.get("hourly", {})
-                    # Find the specific hour
-                    temp = hourly.get("temperature_2m", [])[hour]
-                    humidity = hourly.get("relative_humidity_2m", [])[hour]
-                    wind = hourly.get("wind_speed_10m", [])[hour]
-                    clouds = hourly.get("cloud_cover", [])[hour]
-                    code = hourly.get("weather_code", [])[hour]
                     
+                    # Safety check for hour index
+                    temps = hourly.get("temperature_2m", [])
+                    if not temps or hour >= len(temps):
+                        logger.error(f"Hour {hour} not found in hourly data (length {len(temps)})")
+                        return None
+
                     return {
-                        "temp": temp,
-                        "humidity": humidity,
-                        "wind": wind,
-                        "clouds": clouds,
-                        "code": code,
+                        "temp": temps[hour],
+                        "humidity": hourly.get("relative_humidity_2m", [])[hour],
+                        "wind": hourly.get("wind_speed_10m", [])[hour],
+                        "clouds": hourly.get("cloud_cover", [])[hour],
+                        "code": hourly.get("weather_code", [])[hour],
                         "date": date_str,
                         "time": dt.strftime("%H:%M:%S")
                     }
                 else:
-                    logger.error(f"Open-Meteo returned status {response.status}")
+                    error_text = await response.text()
+                    logger.error(f"Open-Meteo returned status {response.status}: {error_text}")
                     return None
     except Exception:
         logger.exception("Error fetching historical weather")
@@ -168,16 +167,11 @@ async def process_photo_for_exif(message: types.Message, bot: Bot, file_id: str)
 
 @router.message(F.photo)
 async def handle_photo(message: types.Message, bot: Bot):
-    logger.info(f"Received photo message from user {message.from_user.id}")
     # Get the highest resolution photo
     photo = message.photo[-1]
     await process_photo_for_exif(message, bot, photo.file_id)
 
 @router.message(F.document)
 async def handle_document(message: types.Message, bot: Bot):
-    logger.info(f"Received document message from user {message.from_user.id}")
     if message.document.mime_type and message.document.mime_type.startswith("image/"):
-        logger.info(f"Document is an image: {message.document.mime_type}")
         await process_photo_for_exif(message, bot, message.document.file_id)
-    else:
-        logger.info(f"Document is not an image: {message.document.mime_type}")

--- a/handlers/exif_weather.py
+++ b/handlers/exif_weather.py
@@ -168,11 +168,16 @@ async def process_photo_for_exif(message: types.Message, bot: Bot, file_id: str)
 
 @router.message(F.photo)
 async def handle_photo(message: types.Message, bot: Bot):
+    logger.info(f"Received photo message from user {message.from_user.id}")
     # Get the highest resolution photo
     photo = message.photo[-1]
     await process_photo_for_exif(message, bot, photo.file_id)
 
 @router.message(F.document)
 async def handle_document(message: types.Message, bot: Bot):
+    logger.info(f"Received document message from user {message.from_user.id}")
     if message.document.mime_type and message.document.mime_type.startswith("image/"):
+        logger.info(f"Document is an image: {message.document.mime_type}")
         await process_photo_for_exif(message, bot, message.document.file_id)
+    else:
+        logger.info(f"Document is not an image: {message.document.mime_type}")

--- a/handlers/exif_weather.py
+++ b/handlers/exif_weather.py
@@ -1,0 +1,178 @@
+import io
+import logging
+import aiohttp
+from datetime import datetime
+from PIL import Image, ExifTags
+from aiogram import Router, types, F, Bot
+from aiogram.types import FSInputFile
+
+router = Router()
+logger = logging.getLogger(__name__)
+
+def get_decimal_from_dms(dms, ref):
+    """Converts Degrees, Minutes, Seconds to decimal coordinates."""
+    try:
+        degrees = dms[0]
+        minutes = dms[1]
+        seconds = dms[2]
+        
+        # Pillow returns rational numbers which might be objects or tuples
+        # Depending on the version, they could be floats or fractions
+        d = float(degrees)
+        m = float(minutes) / 60.0
+        s = float(seconds) / 3600.0
+        
+        decimal = d + m + s
+        if ref in ['S', 'W']:
+            decimal = -decimal
+        return decimal
+    except Exception:
+        logger.exception("Error converting DMS to decimal")
+        return None
+
+def extract_exif_data(image_bytes):
+    """Extracts GPS and Timestamp from image bytes."""
+    try:
+        img = Image.open(io.BytesIO(image_bytes))
+        exif = img.getexif()
+        if not exif:
+            return None, None
+
+        # GPSInfo is a separate dictionary often indexed by 34853 (0x8825)
+        gps_info = {}
+        for tag, value in exif.items():
+            decoded = ExifTags.TAGS.get(tag, tag)
+            if decoded == "GPSInfo":
+                # For Pillow 10+, getexif() might return GPSInfo in different ways
+                # but standard practice is to use get_ifd(0x8825)
+                pass
+
+        # Try to get GPS IFD specifically
+        gps_ifd = exif.get_ifd(0x8825)
+        if gps_ifd:
+            lat = get_decimal_from_dms(gps_ifd.get(2), gps_ifd.get(1))
+            lon = get_decimal_from_dms(gps_ifd.get(4), gps_ifd.get(3))
+            
+            # Timestamp (DateTimeOriginal is often in the main EXIF or 0x9003)
+            # Try main EXIF first (0x0132 is DateTime, 0x9003 is DateTimeOriginal)
+            dt_str = exif.get(0x9003) or exif.get(0x0132)
+            
+            # If not found in main, try get_ifd(0x8769) for Exif IFD
+            if not dt_str:
+                exif_ifd = exif.get_ifd(0x8769)
+                if exif_ifd:
+                    dt_str = exif_ifd.get(0x9003) or exif_ifd.get(0x9004)
+
+            return (lat, lon), dt_str
+        
+        return None, None
+    except Exception:
+        logger.exception("Error extracting EXIF data")
+        return None, None
+
+async def fetch_historical_weather(lat, lon, dt_str):
+    """Fetches historical weather from Open-Meteo."""
+    try:
+        # EXIF date format: YYYY:MM:DD HH:MM:SS
+        dt = datetime.strptime(dt_str, "%Y:%m:%d %H:%M:%S")
+        date_str = dt.strftime("%Y-%m-%d")
+        hour = dt.hour
+
+        url = "https://archive-api.open-meteo.com/v1/archive"
+        params = {
+            "latitude": lat,
+            "longitude": lon,
+            "start_date": date_str,
+            "end_date": date_str,
+            "hourly": "temperature_2m,relative_humidity_2m,weather_code,wind_speed_10m,cloud_cover",
+            "timezone": "auto"
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, params=params) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    hourly = data.get("hourly", {})
+                    # Find the specific hour
+                    temp = hourly.get("temperature_2m", [])[hour]
+                    humidity = hourly.get("relative_humidity_2m", [])[hour]
+                    wind = hourly.get("wind_speed_10m", [])[hour]
+                    clouds = hourly.get("cloud_cover", [])[hour]
+                    code = hourly.get("weather_code", [])[hour]
+                    
+                    return {
+                        "temp": temp,
+                        "humidity": humidity,
+                        "wind": wind,
+                        "clouds": clouds,
+                        "code": code,
+                        "date": date_str,
+                        "time": dt.strftime("%H:%M:%S")
+                    }
+                else:
+                    logger.error(f"Open-Meteo returned status {response.status}")
+                    return None
+    except Exception:
+        logger.exception("Error fetching historical weather")
+        return None
+
+def get_weather_condition(code):
+    """Maps Open-Meteo weather codes to readable descriptions."""
+    # Simple mapping based on WMO Weather interpretation codes
+    mapping = {
+        0: "Clear sky",
+        1: "Mainly clear", 2: "Partly cloudy", 3: "Overcast",
+        45: "Fog", 48: "Depositing rime fog",
+        51: "Light drizzle", 53: "Moderate drizzle", 55: "Dense drizzle",
+        61: "Slight rain", 63: "Moderate rain", 65: "Heavy rain",
+        71: "Slight snow fall", 73: "Moderate snow fall", 75: "Heavy snow fall",
+        80: "Slight rain showers", 81: "Moderate rain showers", 82: "Violent rain showers",
+        95: "Thunderstorm", 96: "Thunderstorm with slight hail", 99: "Thunderstorm with heavy hail"
+    }
+    return mapping.get(code, "Unknown")
+
+async def process_photo_for_exif(message: types.Message, bot: Bot, file_id: str):
+    """Common logic for processing photo or document."""
+    file = await bot.get_file(file_id)
+    file_bytes = await bot.download_file(file.file_path)
+    # Convert BytesIO to raw bytes
+    raw_bytes = file_bytes.read()
+    
+    coords, dt_str = extract_exif_data(raw_bytes)
+    
+    if coords and coords[0] is not None and coords[1] is not None and dt_str:
+        lat, lon = coords
+        weather = await fetch_historical_weather(lat, lon, dt_str)
+        
+        if weather:
+            condition = get_weather_condition(weather['code'])
+            
+            # Send map
+            await message.answer_location(latitude=lat, longitude=lon)
+            
+            # Send report
+            report = (
+                f"<b>📍 Photo Location:</b> <code>{lat:.4f}, {lon:.4f}</code>\n"
+                f"<b>📅 Taken on:</b> <code>{weather['date']}</code> at <code>{weather['time']}</code>\n\n"
+                f"🌡️ <b>Temperature:</b> <code>{weather['temp']}°C</code>\n"
+                f"☁️ <b>Condition:</b> <code>{condition}</code>\n"
+                f"💧 <b>Humidity:</b> <code>{weather['humidity']}%</code>\n"
+                f"💨 <b>Wind Speed:</b> <code>{weather['wind']} km/h</code>\n"
+                f"🌥️ <b>Cloud Cover:</b> <code>{weather['clouds']}%</code>"
+            )
+            await message.answer(report, parse_mode="HTML")
+        else:
+            logger.info(f"Could not fetch weather for coordinates {coords} and date {dt_str}")
+    else:
+        logger.info(f"No EXIF GPS/Date found in file {file_id} from user {message.from_user.id}")
+
+@router.message(F.photo)
+async def handle_photo(message: types.Message, bot: Bot):
+    # Get the highest resolution photo
+    photo = message.photo[-1]
+    await process_photo_for_exif(message, bot, photo.file_id)
+
+@router.message(F.document)
+async def handle_document(message: types.Message, bot: Bot):
+    if message.document.mime_type and message.document.mime_type.startswith("image/"):
+        await process_photo_for_exif(message, bot, message.document.file_id)

--- a/handlers/help.py
+++ b/handlers/help.py
@@ -17,6 +17,8 @@ async def cmd_help(message: types.Message):
         "/time [city] - Local time (default: Server time)\n"
         "/weather [city] - Current weather or live location\n"
         "/forecast [city] - 5-day weather forecast\n"
+        "<b>📸 Photo Weather:</b>\n"
+        "Send a <b>Photo</b> or <b>File</b> with GPS EXIF data to get historical weather!\n"
         "/rate [CUR1-CUR2] - Exchange rates (default: USD, EUR to RUB)\n"
         "/webcams - Interact with Windy webcams (use /webcams for full help)\n"
         "<b>📍 Circle of Friends:</b>\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "telegram-bot"
-version = "0.7.0"
+version = "0.7.1"
 description = "telegram bot experiments"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/test_exif_weather.py
+++ b/tests/test_exif_weather.py
@@ -1,0 +1,123 @@
+import pytest
+import io
+from unittest.mock import AsyncMock, MagicMock, patch
+from PIL import Image, ImageOps
+from handlers.exif_weather import get_decimal_from_dms, extract_exif_data, get_weather_condition, fetch_historical_weather
+
+def create_test_image_with_exif(lat=None, lon=None, date_str=None):
+    """Creates a small image with EXIF metadata for testing."""
+    img = Image.new('RGB', (10, 10), color='red')
+    exif = img.getexif()
+    
+    if lat is not None and lon is not None:
+        # GPS IFD is 0x8825
+        gps_ifd = {
+            1: 'N' if lat >= 0 else 'S',
+            2: (abs(lat), 0, 0), # Simplified DMS
+            3: 'E' if lon >= 0 else 'W',
+            4: (abs(lon), 0, 0),
+        }
+        # In real EXIF, these are rationals (num, den). Pillow handles some tuples.
+        # This is a simplified mock for extract_exif_data to process.
+        
+    # DateTimeOriginal is 0x9003
+    if date_str:
+        exif[0x9003] = date_str
+        
+    img_byte_arr = io.BytesIO()
+    # img.save(img_byte_arr, format='JPEG', exif=exif) # Pillow might not save all IFDs easily this way in tests
+    # return img_byte_arr.getvalue()
+    return img, exif
+
+def test_get_decimal_from_dms():
+    # 52° 31' 12" N -> 52.52
+    assert round(get_decimal_from_dms((52, 31, 12), 'N'), 2) == 52.52
+    # 13° 24' 36" E -> 13.41
+    assert round(get_decimal_from_dms((13, 24, 36), 'E'), 2) == 13.41
+    # 33° 51' 31" S -> -33.8586...
+    assert round(get_decimal_from_dms((33, 51, 31), 'S'), 4) == -33.8586
+
+def test_get_weather_condition():
+    assert get_weather_condition(0) == "Clear sky"
+    assert get_weather_condition(95) == "Thunderstorm"
+    assert get_weather_condition(999) == "Unknown"
+
+@pytest.mark.asyncio
+async def test_fetch_historical_weather_success():
+    mock_response = {
+        "hourly": {
+            "temperature_2m": [10.0] * 24,
+            "relative_humidity_2m": [50] * 24,
+            "wind_speed_10m": [5.0] * 24,
+            "cloud_cover": [10] * 24,
+            "weather_code": [0] * 24
+        }
+    }
+    
+    with patch('aiohttp.ClientSession.get') as mock_get:
+        mock_ctx = MagicMock()
+        mock_ctx.__aenter__.return_value.status = 200
+        mock_ctx.__aenter__.return_value.json = AsyncMock(return_value=mock_response)
+        mock_get.return_value = mock_ctx
+        
+        result = await fetch_historical_weather(52.52, 13.41, "2023:05:20 12:00:00")
+        
+        assert result is not None
+        assert result['temp'] == 10.0
+        assert result['date'] == "2023-05-20"
+        assert result['time'] == "12:00:00"
+
+@patch('handlers.exif_weather.extract_exif_data')
+@patch('handlers.exif_weather.fetch_historical_weather')
+@pytest.mark.asyncio
+async def test_handle_photo_success(mock_fetch, mock_extract):
+    # Mock data
+    mock_extract.return_value = ((52.52, 13.41), "2023:05:20 12:00:00")
+    mock_fetch.return_value = {
+        "temp": 20.5, "humidity": 45, "wind": 12, "clouds": 5, "code": 0,
+        "date": "2023-05-20", "time": "12:00:00"
+    }
+    
+    # Mock message and bot
+    message = AsyncMock()
+    bot = AsyncMock()
+    photo = MagicMock()
+    photo.file_id = "test_file_id"
+    message.photo = [photo]
+    
+    # Mock bot methods
+    file_mock = MagicMock()
+    file_mock.file_path = "path/to/file"
+    bot.get_file.return_value = file_mock
+    
+    # Mock download_file
+    download_mock = MagicMock()
+    download_mock.read.return_value = b"fake_bytes"
+    bot.download_file.return_value = download_mock
+    
+    from handlers.exif_weather import handle_photo
+    await handle_photo(message, bot)
+    
+    # Verify outcomes
+    message.answer_location.assert_called_once_with(latitude=52.52, longitude=13.41)
+    message.answer.assert_called_once()
+    assert "20.5°C" in message.answer.call_args[0][0]
+
+@patch('handlers.exif_weather.extract_exif_data')
+@pytest.mark.asyncio
+async def test_handle_photo_no_exif(mock_extract):
+    mock_extract.return_value = (None, None)
+    
+    message = AsyncMock()
+    bot = AsyncMock()
+    photo = MagicMock()
+    message.photo = [photo]
+    bot.get_file.return_value = MagicMock(file_path="path")
+    bot.download_file.return_value = MagicMock(read=lambda: b"bytes")
+    
+    from handlers.exif_weather import handle_photo
+    await handle_photo(message, bot)
+    
+    # Should NOT reply to user
+    message.answer_location.assert_not_called()
+    message.answer.assert_not_called()

--- a/tests/test_exif_weather.py
+++ b/tests/test_exif_weather.py
@@ -1,33 +1,8 @@
 import pytest
 import io
 from unittest.mock import AsyncMock, MagicMock, patch
-from PIL import Image, ImageOps
+from PIL import Image, ExifTags
 from handlers.exif_weather import get_decimal_from_dms, extract_exif_data, get_weather_condition, fetch_historical_weather
-
-def create_test_image_with_exif(lat=None, lon=None, date_str=None):
-    """Creates a small image with EXIF metadata for testing."""
-    img = Image.new('RGB', (10, 10), color='red')
-    exif = img.getexif()
-    
-    if lat is not None and lon is not None:
-        # GPS IFD is 0x8825
-        gps_ifd = {
-            1: 'N' if lat >= 0 else 'S',
-            2: (abs(lat), 0, 0), # Simplified DMS
-            3: 'E' if lon >= 0 else 'W',
-            4: (abs(lon), 0, 0),
-        }
-        # In real EXIF, these are rationals (num, den). Pillow handles some tuples.
-        # This is a simplified mock for extract_exif_data to process.
-        
-    # DateTimeOriginal is 0x9003
-    if date_str:
-        exif[0x9003] = date_str
-        
-    img_byte_arr = io.BytesIO()
-    # img.save(img_byte_arr, format='JPEG', exif=exif) # Pillow might not save all IFDs easily this way in tests
-    # return img_byte_arr.getvalue()
-    return img, exif
 
 def test_get_decimal_from_dms():
     # 52° 31' 12" N -> 52.52
@@ -37,10 +12,57 @@ def test_get_decimal_from_dms():
     # 33° 51' 31" S -> -33.8586...
     assert round(get_decimal_from_dms((33, 51, 31), 'S'), 4) == -33.8586
 
+def test_get_decimal_from_dms_invalid_input():
+    # Test invalid formats
+    assert get_decimal_from_dms(None, 'N') is None
+    assert get_decimal_from_dms((52, 31), 'N') is None
+    assert get_decimal_from_dms("invalid", 'N') is None
+    assert get_decimal_from_dms((52, 31, "invalid"), 'N') is None
+
 def test_get_weather_condition():
     assert get_weather_condition(0) == "Clear sky"
     assert get_weather_condition(95) == "Thunderstorm"
     assert get_weather_condition(999) == "Unknown"
+
+@patch('PIL.Image.open')
+def test_extract_exif_data_success(mock_image_open):
+    mock_img = MagicMock()
+    mock_exif = MagicMock()
+    mock_gps_ifd = {
+        1: 'N', 2: (52, 0, 0),
+        3: 'E', 4: (13, 0, 0),
+    }
+    # Mock exif.get for 0x9003 (DateTimeOriginal)
+    mock_exif.get.side_effect = lambda key: "2023:05:20 12:00:00" if key == 0x9003 else None
+    mock_exif.get_ifd.return_value = mock_gps_ifd
+    mock_img.getexif.return_value = mock_exif
+    mock_image_open.return_value = mock_img
+
+    coords, dt_str = extract_exif_data(b"fake_image_bytes")
+    assert coords == (52.0, 13.0)
+    assert dt_str == "2023:05:20 12:00:00"
+
+@patch('PIL.Image.open')
+def test_extract_exif_data_no_exif(mock_image_open):
+    mock_img = MagicMock()
+    mock_img.getexif.return_value = None
+    mock_image_open.return_value = mock_img
+
+    coords, dt_str = extract_exif_data(b"fake_image_bytes")
+    assert coords is None
+    assert dt_str is None
+
+@patch('PIL.Image.open')
+def test_extract_exif_data_no_gps(mock_image_open):
+    mock_img = MagicMock()
+    mock_exif = MagicMock()
+    mock_exif.get_ifd.return_value = None # No GPS IFD
+    mock_img.getexif.return_value = mock_exif
+    mock_image_open.return_value = mock_img
+
+    coords, dt_str = extract_exif_data(b"fake_image_bytes")
+    assert coords is None
+    assert dt_str is None
 
 @pytest.mark.asyncio
 async def test_fetch_historical_weather_success():


### PR DESCRIPTION
This PR adds a new feature that extracts EXIF GPS and timestamp data from photos and documents sent to the bot, and provides historical weather for that specific time and place using the Open-Meteo API.

Key changes:
- New handler `handlers/exif_weather.py` to process photos and documents.
- Integration with Open-Meteo Historical API.
- Automatic location sending via `answer_location`.
- Unit tests in `tests/test_exif_weather.py`.
- Updated help documentation.
- Version bump to 0.7.1.